### PR TITLE
home-manager: compatibility update to support latest version (fixes #1)

### DIFF
--- a/modules/nixos/home-manager.nix
+++ b/modules/nixos/home-manager.nix
@@ -61,7 +61,7 @@
           ) (name: nixosConfig.blox.profiles.${name});
       }
       user.home-config);
-    hmUsers = filterAttrs (name: { isNormalUser, ...}: isNormalUser) config.users.users;
+    hmUsers = filterAttrs (name: { isNormalUser, ...}: isNormalUser) config.blox.users.users;
   in {
     home-manager.users = mapAttrs makeHM hmUsers;
   };

--- a/modules/nixos/users.nix
+++ b/modules/nixos/users.nix
@@ -20,6 +20,7 @@ in {
     users = mkOption {
       description = "Users with sane defaults";
       type = with types; loaOf attrs;
+      apply = mapAttrs user;
       default = [];
     };
   };
@@ -49,7 +50,7 @@ in {
   config = {
     users = {
       mutableUsers = mkDefault false;
-      users = (mapAttrs user cfg.users);
+      users = cfg.users;
     };
   };
 }


### PR DESCRIPTION
home-manager implementation was broken as it is now referencing
`users.users` too: https://github.com/rycee/home-manager/issues/594
'nixos-module-user-pkgs' feature has introduced circular dependencies
as blox already establishes a reference between the too attributes
where the dependency link has the opposite direction.
```
      /-------- via blox -------\
      |                         |
      |                         V
/-------------\         /--------------------\
| users.users | <------ | home-manager.users |
\-------------/         \--------------------/
```
This has been fixed by using the already existing `blox.users.users`
convenience attribute to derive both `home-manager.users` and
`users.users`.
```
          /------------------\
      /-- | blox.users.users | --\
      |   \------------------/   |
      |                          |
      V                          V
/-------------\         /--------------------\
| users.users | <------ | home-manager.users |
\-------------/         \--------------------/
```
*WARNING*: This breaks configurations which doesn't use
`blox.users.users`.